### PR TITLE
Add basic dashboard page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a simple landing page for **ZENKORO**.
 
 ## Running the Frontend
 
-Open `index.html` in your browser to see the page. Styling is provided in `style.css`. The login button links to `login.html`, which uses `login.js` to communicate with the backend.
+Open `index.html` in your browser to see the page. Styling is provided in `style.css`. The login button links to `login.html`, which uses `login.js` to communicate with the backend. After a successful login you will be redirected to `dashboard.html` where a placeholder portfolio dashboard is displayed.
 
 The landing page now supports connecting an Ethereum wallet via MetaMask. Click
 the **Connect Wallet** button to trigger MetaMask and grant access to your

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dashboard - ZENKORO</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
+</head>
+<body class="auth-section">
+  <div class="container">
+    <div class="row justify-content-center w-100">
+      <div class="col-lg-8">
+        <h1 class="display-4 fw-bold text-center mb-4">Portfolio Dashboard</h1>
+        <div class="auth-card shadow text-light">
+          <table class="table table-dark table-striped mb-0">
+            <thead>
+              <tr>
+                <th scope="col">Token</th>
+                <th scope="col">Holdings</th>
+                <th scope="col">Value (USD)</th>
+                <th scope="col">24h Change</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Bitcoin (BTC)</td>
+                <td>--</td>
+                <td>--</td>
+                <td>--</td>
+              </tr>
+              <tr>
+                <td>Ethereum (ETH)</td>
+                <td>--</td>
+                <td>--</td>
+                <td>--</td>
+              </tr>
+              <tr>
+                <td>Cardano (ADA)</td>
+                <td>--</td>
+                <td>--</td>
+                <td>--</td>
+              </tr>
+              <tr>
+                <td>Polkadot (DOT)</td>
+                <td>--</td>
+                <td>--</td>
+                <td>--</td>
+              </tr>
+              <tr>
+                <td>Solana (SOL)</td>
+                <td>--</td>
+                <td>--</td>
+                <td>--</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <footer class="py-4 text-center footer mt-auto">
+    <div class="container">
+      <small>&copy; 2025 Zenkoro. All rights reserved.</small>
+    </div>
+  </footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/login.js
+++ b/login.js
@@ -20,7 +20,7 @@ form.addEventListener('submit', async function (e) {
             const modal = bootstrap.Modal.getInstance(modalEl) || new bootstrap.Modal(modalEl);
             modal.hide();
           } else if (window.location.pathname.endsWith('login.html')) {
-            window.location.href = 'index.html';
+            window.location.href = 'dashboard.html';
           }
         } else {
           errorEl.classList.remove('d-none');


### PR DESCRIPTION
## Summary
- create `dashboard.html` to show placeholder crypto portfolio data
- update login flow to redirect to the dashboard
- mention new dashboard page in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68478f3cc2288324af7219632788cf83