### PR TITLE
Add SVG mockups

### DIFF
--- a/img/allocation-chart.svg
+++ b/img/allocation-chart.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <circle cx="100" cy="100" r="80" fill="#111" />
+  <path d="M100 20 A80 80 0 0 1 180 100 L100 100 Z" fill="#ffd95e" />
+  <path d="M180 100 A80 80 0 0 1 100 180 L100 100 Z" fill="#ff7f63" />
+  <path d="M100 180 A80 80 0 0 1 20 100 L100 100 Z" fill="#f9b64d" />
+  <path d="M20 100 A80 80 0 0 1 100 20 L100 100 Z" fill="#b87333" />
+</svg>

--- a/img/hero-chart.svg
+++ b/img/hero-chart.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 160">
+  <rect width="300" height="160" fill="#111" />
+  <polyline points="0,140 50,130 100,90 150,100 200,70 250,80 300,40" stroke="#ffd95e" stroke-width="3" fill="none" />
+</svg>

--- a/img/performance-chart.svg
+++ b/img/performance-chart.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
+  <rect width="300" height="200" fill="#111" />
+  <polyline points="10,180 60,120 110,150 160,90 210,110 260,70 290,80" stroke="#ffd95e" stroke-width="3" fill="none" />
+</svg>

--- a/img/profit-chart.svg
+++ b/img/profit-chart.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
+  <rect width="300" height="200" fill="#111" />
+  <rect x="40" y="120" width="40" height="60" fill="#ffd95e" />
+  <rect x="100" y="80" width="40" height="100" fill="#ff7f63" />
+  <rect x="160" y="100" width="40" height="80" fill="#f9b64d" />
+  <rect x="220" y="60" width="40" height="120" fill="#b87333" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <p class="lead mb-4 animate">A unified view of your entire crypto portfolio across chains &mdash; ZENKORO puts you in control with smart insights and uncompromising privacy</p>
     <div class="row justify-content-center align-items-center mb-3 animate">
       <div class="col-md-7">
-        <canvas id="heroChart" height="160" class="w-100 hero-graph"></canvas>
+        <img src="img/hero-chart.svg" alt="Portfolio growth" height="160" class="w-100 hero-graph" />
       </div>
       <div class="col-md-5 text-start hero-stats mt-4 mt-md-0">
         <h3 class="h5">Portfolio Value</h3>
@@ -46,7 +46,7 @@
   <div class="container">
     <div class="row align-items-center gy-4">
       <div class="col-md-6">
-        <canvas id="performanceChart" height="200" class="screenshot-img w-100"></canvas>
+        <img src="img/performance-chart.svg" alt="Portfolio performance" height="200" class="screenshot-img w-100" />
       </div>
       <div class="col-md-6">
         <h2 class="fw-bold mb-3 animate">Unified Portfolio View</h2>
@@ -60,7 +60,7 @@
   <div class="container">
     <div class="row align-items-center gy-4">
       <div class="col-md-6 order-md-2">
-        <canvas id="allocationChart" height="200" class="screenshot-img w-100"></canvas>
+        <img src="img/allocation-chart.svg" alt="Asset allocation" height="200" class="screenshot-img w-100" />
       </div>
       <div class="col-md-6 order-md-1 text-md-end">
         <h2 class="fw-bold mb-3 animate">Actionable Insights</h2>
@@ -74,7 +74,7 @@
   <div class="container">
     <div class="row align-items-center gy-4">
       <div class="col-md-6">
-        <canvas id="profitChart" height="200" class="screenshot-img w-100"></canvas>
+        <img src="img/profit-chart.svg" alt="Profit and loss" height="200" class="screenshot-img w-100" />
       </div>
       <div class="col-md-6">
         <h2 class="fw-bold mb-3 animate">Privacy First</h2>


### PR DESCRIPTION
## Summary
- add example SVG charts for hero and feature sections
- replace canvas elements on homepage with SVG mockups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848e5ed52688324b1749d370a6dfd7c